### PR TITLE
added a simple header parser

### DIFF
--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -9,7 +9,20 @@
             <span class="px-2 text-right w-1/2">
             {{ $statusCode }}
         </span>
-        </div>
-        <div class="w-full text-white text-center {{ $bgColor }}"></div>
     </div>
+    @if(count($headers))
+    <div class="my-1 w-full text-white text-center">
+        <span class="uppercase mr-1">Headers</span>
+        @foreach($headers as $key => $value)
+            <div class="w-full text-white {{ $bgColor }}">
+                <span class="px-2 text-left w-1/2">
+                    <span>{{ $key }}</span>
+                </span>
+                <span class="px-2 text-right w-1/2">
+                    {{ $value }}
+                </span>
+            </div>
+        @endforeach
+    </div>
+    @endif
 </div>

--- a/src/Commands/VisitCommand.php
+++ b/src/Commands/VisitCommand.php
@@ -19,6 +19,7 @@ class VisitCommand extends Command
     public $signature = '
         visit {url}
             {--method=get}
+            {--headers=}
             {--user=}
             {--no-color}
         ';
@@ -70,6 +71,22 @@ class VisitCommand extends Command
         return $method;
     }
 
+    protected function getHeaders(): array
+    {
+        $defaultHeaders = [
+            "Content-Type" => "application/json"
+        ];
+        
+        $headersString = $this->option('headers');
+        $headers = json_decode($headersString, true);
+
+        if(!$headersString || !$headers) {
+            return $defaultHeaders;
+        }
+
+        return $headers;
+    }
+
     protected function makeRequest(): TestResponse
     {
         $method = $this->getMethod();
@@ -83,6 +100,7 @@ class VisitCommand extends Command
     {
         $view = view('visit::header', [
             'method' => $this->option('method'),
+            'headers' => $this->getHeaders(),
             'url' => $this->argument('url'),
             'statusCode' => $response->getStatusCode(),
             'content' => $response->content(),


### PR DESCRIPTION
added `--header` signature for sending headers
example usage:
`php artisan visit / --method get --headers '{"x-api-key: "someapikeythatisextremelyuniqueandfancy"}`